### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,4 +1,6 @@
 name: Unit Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/mrwiora/tpm2-kira/security/code-scanning/1](https://github.com/mrwiora/tpm2-kira/security/code-scanning/1)

To resolve the issue, you should explicitly set the `permissions` key in the workflow file to limit the permissions of the GITHUB_TOKEN. This can be done either at the root of the workflow (to apply to all jobs) or inside the specific job (`unit-tests`) block. Since the workflow shown does not perform any actions that require write access (e.g., no pushes, issue creation, or PR editing), you should set `contents: read`, which is the minimal required permission for checking out code and running tests. Place the following block at the root of the workflow file, just below the `name` field and before `on:`. No additional methods, imports, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
