### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,4 +1,6 @@
 name: Integration Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/mrwiora/tpm2-kira/security/code-scanning/2](https://github.com/mrwiora/tpm2-kira/security/code-scanning/2)

The best fix is to add a `permissions` block to the workflow, either at the root (recommended for a single-job workflow) or at the job level, and restrict permissions to the minimum required. Based on the workflow's activities (checkout, dependencies, tests, no publishing or PR actions), it only requires `contents: read` for reading the source code. This change should be made immediately below the `name` field and before the `on:` block to set the permissions for all jobs in the workflow. No additional imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
